### PR TITLE
Batch process game callback data

### DIFF
--- a/fetch.gs
+++ b/fetch.gs
@@ -153,13 +153,27 @@ function runConfiguredFetchV2() {
       existingUrlSet.add(gameUrl);
     }
     if (rows.length) {
+      var start = gamesSheet.getLastRow() + 1;
       appendRowsV2_(gamesSheet, rows, selectedHeaders.length);
+      var end = start + rows.length - 1;
+      if (cfg.groups && cfg.groups.callback && cfg.groups.callback.calculateNew) {
+        populateCallbackForRange_(headersSheet, gamesSheet, start, end);
+      }
     }
   }
 
   // Recalculate derived across sheet if requested
   if (cfg.groups && cfg.groups.derived && cfg.groups.derived.recalculate) {
     recalcDerivedV2_(headersSheet, gamesSheet, selectedHeaders);
+  }
+
+  // If Callback group is toggled to recalculate, run over all rows
+  if (cfg.groups && cfg.groups.callback && cfg.groups.callback.recalculate) {
+    // Entire data range
+    var lastRowCb = gamesSheet.getLastRow();
+    if (lastRowCb >= 2) {
+      populateCallbackForRange_(headersSheet, gamesSheet, 2, lastRowCb);
+    }
   }
 }
 


### PR DESCRIPTION
Add a new "Callback" data type to fetch and display additional game details from the `chess.com/callback/live/game/<id>` endpoint.

This allows users to discover available fields, batch process existing games by selection or URL, and automatically populate callback data for newly fetched or recalculated rows.

---
<a href="https://cursor.com/background-agent?bcId=bc-43efa94c-51b0-4960-bcea-8b376180e401">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43efa94c-51b0-4960-bcea-8b376180e401">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

